### PR TITLE
Fix #122 clicking on tools tips for grouped events

### DIFF
--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -301,7 +301,7 @@ function createTooltipGroupHTML(group) {
     var html = "";
     group.forEach(function (event) {
         if (event && typeof event === 'object') {
-            html += '<a onclick="return false" href="#' + event["id"] + '">' + toTitleCase(renameTypeLabel(event.data_type)) + '</a><br>'
+            html += '<a onclick="return true" href="#' + event["id"] + '">' + toTitleCase(renameTypeLabel(event.name)) + '</a><br>'
         }
     });
     return html;


### PR DESCRIPTION
Fixed clicking on tools tips for grouped events and also the title of event. 
Line# 304 on `timeline.js.erb`