### PR TITLE
Issue 155 Timeline starts and stops at relevant dates

### DIFF
--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -211,13 +211,15 @@ function visibleTypes() {
  * Given a date, check if it is greater than the minimum date, and return it instead if it is
  * @param date - the date to validate
  * @param minDate - the date that is the current minimum
+ * @param zoom - boolean whether or not to zoom in
  * @returns Date - smaller of two values
  */
-function getMinDate(date, minDate) {
-    if (date < minDate) {
+function getMinDate(date, minDate, zoom) {
+    if (zoom) {
+        console.log('zoom in');
+    } else if (date < minDate) {
         return date;
-    }
-    else {
+    } else {
         return minDate;
     }
 }
@@ -226,13 +228,15 @@ function getMinDate(date, minDate) {
  * Given a date, check if it is greater than the maximum date, and return it instead if it is
  * @param date - the date to validate
  * @param maxDate - the date that is the current maximum
+ * @param zoom - boolean whether or not to zoom in
  * @returns Date - larger of two values
  */
-function getMaxDate(date, maxDate) {
-    if (date > maxDate) {
+function getMaxDate(date, maxDate, zoom) {
+    if (zoom) {
+        console.log('zoom in');
+    } else if (date > maxDate) {
         return date;
-    }
-    else {
+    } else {
         return maxDate;
     }
 }
@@ -269,12 +273,12 @@ var groupSize = 5;
  * Function to first find minimum and maximum dates, append the checkboxes, and finally draw the timeline
  * Called on the timeline's first run
  */
-function initializeTimeline() {
+function initializeTimeline(zoom) {
     $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
-        minDate = getMinDate(date, minDate);
-        maxDate = getMaxDate(date, maxDate);
+        minDate = getMinDate(date, minDate, false);
+        maxDate = getMaxDate(date, maxDate, false);
         var data_type = $(this).attr('id');
         validTypes = updateTypes(data_type, validTypes)
     });
@@ -634,7 +638,7 @@ function createGroups(eventsInGroup) {
 }
 
 $(document).ready(function () {
-    initializeTimeline();
+    initializeTimeline(false);
 
     var $wrapper = $('#cd-timeline');
     $wrapper.find('.cd-timeline-block').sort(function (a, b) {
@@ -643,6 +647,19 @@ $(document).ready(function () {
         return +date2 - +date1;
     })
         .appendTo( $wrapper );
+
+    $('#zoom').click(function() {
+        var zoom = $('#zoomBool').val();
+        if ($('#zoomBool').val() == "true") {
+            $('#zoomBool').val("false");
+            zoom = false;
+        } else {
+            $('#zoomBool').val("true");
+            zoom = true;
+        }
+        $('#toggle-block').empty();
+        initializeTimeline(zoom);
+    });
 
     $('#cd-timeline').on('click', 'a', function (event) {
         event.preventDefault();

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -263,24 +263,6 @@ var datePadLocations;
 var groupSize = 5;
 var numFix = 0
 
-
-function getRelevantDates(data_type, date) {
-    var type = data_type.toLowerCase();
-    if (type == 'vcc') {
-        minDate = getMinDate(date, minDate);
-        minDate.setDate(minDate.getDate()-10);
-    } else if (type == 'fix') {
-        if (numFix > 0) {
-            maxDate = getMaxDate(date, maxDate);
-            maxDate.setDate(maxDate.getDate()+10);
-        } else {
-            maxDate = date;
-            maxDate.setDate(maxDate.getDate()+10);
-        }
-        numFix += 1;
-    }
-}
-
 /**
  * Function to first find minimum and maximum dates, append the checkboxes, and finally draw the timeline
  * Called on the timeline's first run
@@ -292,7 +274,20 @@ function initializeTimeline(zoom) {
         var data_type = $(this).attr('id');
         validTypes = updateTypes(data_type, validTypes);
         if (zoom) {
-            getRelevantDates(data_type, date);
+            var type = data_type.toLowerCase();
+            if (type == 'vcc') {
+                minDate = getMinDate(date, minDate);
+                minDate.setDate(minDate.getDate()-10);
+            } else if (type == 'fix') {
+                if (numFix > 0) {
+                    maxDate = getMaxDate(date, maxDate);
+                    maxDate.setDate(maxDate.getDate()+10);
+                } else {
+                    maxDate = date;
+                    maxDate.setDate(maxDate.getDate()+10);
+                }
+                numFix += 1;
+            }
         } else {
             //default  view
             minDate = getMinDate(date, minDate);

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -211,13 +211,10 @@ function visibleTypes() {
  * Given a date, check if it is greater than the minimum date, and return it instead if it is
  * @param date - the date to validate
  * @param minDate - the date that is the current minimum
- * @param zoom - boolean whether or not to zoom in
  * @returns Date - smaller of two values
  */
-function getMinDate(date, minDate, zoom) {
-    if (zoom) {
-        console.log('zoom in');
-    } else if (date < minDate) {
+function getMinDate(date, minDate) {
+    if (date < minDate) {
         return date;
     } else {
         return minDate;
@@ -228,13 +225,10 @@ function getMinDate(date, minDate, zoom) {
  * Given a date, check if it is greater than the maximum date, and return it instead if it is
  * @param date - the date to validate
  * @param maxDate - the date that is the current maximum
- * @param zoom - boolean whether or not to zoom in
  * @returns Date - larger of two values
  */
-function getMaxDate(date, maxDate, zoom) {
-    if (zoom) {
-        console.log('zoom in');
-    } else if (date > maxDate) {
+function getMaxDate(date, maxDate) {
+    if (date > maxDate) {
         return date;
     } else {
         return maxDate;
@@ -267,7 +261,25 @@ var slots = width / iconWidth; // number of different date slots
 
 var datePadLocations;
 var groupSize = 5;
+var numFix = 0
 
+
+function getRelevantDates(data_type, date) {
+    var type = data_type.toLowerCase();
+    if (type == 'vcc') {
+        minDate = getMinDate(date, minDate);
+        minDate.setDate(minDate.getDate()-10);
+    } else if (type == 'fix') {
+        if (numFix > 0) {
+            maxDate = getMaxDate(date, maxDate);
+            maxDate.setDate(maxDate.getDate()+10);
+        } else {
+            maxDate = date;
+            maxDate.setDate(maxDate.getDate()+10);
+        }
+        numFix += 1;
+    }
+}
 
 /**
  * Function to first find minimum and maximum dates, append the checkboxes, and finally draw the timeline
@@ -277,10 +289,16 @@ function initializeTimeline(zoom) {
     $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
-        minDate = getMinDate(date, minDate, false);
-        maxDate = getMaxDate(date, maxDate, false);
         var data_type = $(this).attr('id');
-        validTypes = updateTypes(data_type, validTypes)
+        validTypes = updateTypes(data_type, validTypes);
+        if (zoom) {
+            getRelevantDates(data_type, date);
+        } else {
+            //default  view
+            minDate = getMinDate(date, minDate);
+            maxDate = getMaxDate(date, maxDate);
+        }
+
     });
     datePadLocations = getDatePadLocations(minDate, maxDate, slots);
     generateTypeSwitches(validTypes);

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -265,7 +265,6 @@ function initializeTimeline(zoom) {
     var minDate = getDate(Date.now()),
         maxDate = getDate('0');
     $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
-        min = minDate;
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
         var data_type = $(this).attr('id');

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -245,8 +245,7 @@ var validTypes = [];
  * when the timeline is drawn
  * @type {Date}
  */
-var minDate = getDate(Date.now()),
-    maxDate = getDate('0');
+
 
 
 var margin = {top: 10, right: 20, bottom: 30, left: 60},
@@ -261,14 +260,16 @@ var slots = width / iconWidth; // number of different date slots
 
 var datePadLocations;
 var groupSize = 5;
-var numFix = 0
 
 /**
  * Function to first find minimum and maximum dates, append the checkboxes, and finally draw the timeline
  * Called on the timeline's first run
  */
 function initializeTimeline(zoom) {
+    var minDate = getDate(Date.now()),
+        maxDate = getDate('0');
     $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
+        min = minDate;
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
         var data_type = $(this).attr('id');
@@ -277,27 +278,20 @@ function initializeTimeline(zoom) {
             var type = data_type.toLowerCase();
             if (type == 'vcc') {
                 minDate = getMinDate(date, minDate);
-                minDate.setDate(minDate.getDate()-10);
             } else if (type == 'fix') {
-                if (numFix > 0) {
                     maxDate = getMaxDate(date, maxDate);
-                    maxDate.setDate(maxDate.getDate()+10);
-                } else {
-                    maxDate = date;
-                    maxDate.setDate(maxDate.getDate()+10);
-                }
-                numFix += 1;
             }
         } else {
             //default  view
             minDate = getMinDate(date, minDate);
             maxDate = getMaxDate(date, maxDate);
         }
-
     });
+    console.log(minDate);
+    console.log(maxDate);
     datePadLocations = getDatePadLocations(minDate, maxDate, slots);
     generateTypeSwitches(validTypes);
-    generateTimeline();
+    generateTimeline(minDate, maxDate);
 }
 
 /**
@@ -349,7 +343,7 @@ function setupVerticalTimeline() {
 /**
  * Function to draw the timeline - draws both the horizontal and vertical timeline
  */
-function generateTimeline() {
+function generateTimeline(minDate, maxDate) {
     removeSVG();
     setupVerticalTimeline();
     var timelineData = createTimelineData();

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -207,6 +207,42 @@ function visibleTypes() {
 
 }
 
+
+function GetDateRange(zoom) {
+    this.minDate = getDate(Date.now());
+    this.maxDate = getDate('0');
+    this.absMinDate = getDate(Date.now());
+    this.absMaxDate = getDate('0');
+    this.numVcc = 0;
+    this.numFix = 0;
+    this.zoom = zoom;
+    var rangeFinder = this;
+    $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
+        var string_date = $(this).find("#date").text().trim();
+        var date = getDate(string_date);
+        var data_type = $(this).attr('id');
+        validTypes = updateTypes(data_type, validTypes);
+        rangeFinder.absMinDate = getMinDate(date, rangeFinder.absMinDate);
+        rangeFinder.absMaxDate = getMaxDate(date, rangeFinder.absMaxDate);
+        if (rangeFinder.zoom) {
+            var type = data_type.toLowerCase();
+            if (type == 'vcc') {
+                rangeFinder.numVcc += 1;
+                rangeFinder.minDate = getMinDate(date, rangeFinder.minDate);
+            } else if (type == 'fix') {
+                rangeFinder.numFix += 1;
+                rangeFinder.maxDate = getMaxDate(date, rangeFinder.maxDate);
+            }
+        }
+    });
+    if ((rangeFinder.zoom && (rangeFinder.numVcc == 0)) || !rangeFinder.zoom ) {
+        rangeFinder.minDate = rangeFinder.absMinDate;
+    }
+    if ((rangeFinder.zoom && (rangeFinder.numFix == 0)) || !rangeFinder.zoom) {
+        rangeFinder.maxDate = rangeFinder.absMaxDate;
+    }
+}
+
 /**
  * Given a date, check if it is greater than the minimum date, and return it instead if it is
  * @param date - the date to validate
@@ -278,26 +314,9 @@ var groupSize = 5;
  * Called on the timeline's first run
  */
 function initializeTimeline(zoom) {
-    var minDate = getDate(Date.now()),
-        maxDate = getDate('0');
-    $(".cd-timeline-block").each(function () { // Read events for the first time and find min / max date
-        var string_date = $(this).find("#date").text().trim();
-        var date = getDate(string_date);
-        var data_type = $(this).attr('id');
-        validTypes = updateTypes(data_type, validTypes);
-        if (zoom) {
-            var type = data_type.toLowerCase();
-            if (type == 'vcc') {
-                minDate = getMinDate(date, minDate);
-            } else if (type == 'fix') {
-                    maxDate = getMaxDate(date, maxDate);
-            }
-        } else {
-            //default  view
-            minDate = getMinDate(date, minDate);
-            maxDate = getMaxDate(date, maxDate);
-        }
-    });
+    var dates = new GetDateRange(zoom);
+    var minDate = dates.minDate;
+    var maxDate = dates.maxDate;
     datePadLocations = getDatePadLocations(minDate, maxDate, slots);
     generateTypeSwitches(validTypes);
     generateTimeline(minDate, maxDate);
@@ -353,8 +372,6 @@ function setupVerticalTimeline() {
         }
     });
 }
-
-
 
 /**
  * Function to draw the timeline - draws both the horizontal and vertical timeline

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -235,7 +235,6 @@ function GetDateRange(zoom) {
             if (rangeFinder.zoom) {
                 rangeFinder.minDate = getMinDate(date, rangeFinder.minDate);
             }
-
         }
         if (type == 'fix') {
             rangeFinder.numFix += 1;
@@ -252,6 +251,12 @@ function GetDateRange(zoom) {
     }
     if ((rangeFinder.zoom && (rangeFinder.numFix == 0)) || !rangeFinder.zoom) {
         rangeFinder.maxDate = rangeFinder.absMaxDate;
+    }
+    if (zoom) {
+        var timeDiff = Math.abs(this.maxDate.getTime() - this.minDate.getTime());
+        var pad = Math.round(0.05 * timeDiff);
+        this.minDate.setTime(this.minDate.getTime() - pad);
+        this.maxDate.setTime(this.maxDate.getTime() + pad);
     }
 
 }

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -235,6 +235,22 @@ function getMaxDate(date, maxDate) {
     }
 }
 
+/**
+ * Check if the given date is within the min and max dates
+ *
+ * @param min
+ * @param max
+ * @param date
+ * @returns {boolean}
+ */
+function dateInRange(min, max, date){
+    var start = new Date(min.getTime());
+    var end = new Date(max.getTime());
+    start.setHours(0,0,0,0);
+    end.setHours(23,59,59,999);
+    return (date >= start && date <= end);
+}
+
 var validTypes = [];
 /**
  * Global variables used to store the minimum and maximum date, computed by initialize timeline and used
@@ -285,6 +301,13 @@ function initializeTimeline(zoom) {
     datePadLocations = getDatePadLocations(minDate, maxDate, slots);
     generateTypeSwitches(validTypes);
     generateTimeline(minDate, maxDate);
+    dataToggleCallback(minDate, maxDate);
+}
+
+function dataToggleCallback(minDate, maxDate) {
+    $(document).on("change", ".data-toggles", function () {
+        generateTimeline(minDate, maxDate);
+    });
 }
 
 /**
@@ -339,7 +362,8 @@ function setupVerticalTimeline() {
 function generateTimeline(minDate, maxDate) {
     removeSVG();
     setupVerticalTimeline();
-    var timelineData = createTimelineData();
+    var timelineDataObj = new  CreateTimelineData(minDate, maxDate);
+    var timelineData = timelineDataObj.timelineData;
     createGroupedObjects(timelineData);
     var toAdd = document.createDocumentFragment();
 
@@ -551,42 +575,48 @@ function generateTimeline(minDate, maxDate) {
  * }
  *
  */
-function createTimelineData() {
-    var timelineData = {};
+function CreateTimelineData(minDate, maxDate) {
+    this.minDate = minDate;
+    this.maxDate = maxDate;
+    this.timelineData = {};
+    var creator = this;
     $(".cd-timeline-block").each(function () {
-        var id = $(this).find("a").attr('id');
-        var name = $(this).find("#title").text();
-        var description = $(this).find("#description").text().trim();
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
-        var data_type = $(this).attr('id');
+        if (dateInRange(creator.minDate, creator.maxDate, date)) {
+            var id = $(this).find("a").attr('id');
+            var name = $(this).find("#title").text();
+            var description = $(this).find("#description").text().trim();
 
-        var eventAsDict = {
-            "id": id,
-            "name": name,
-            "description": description,
-            "date": date,
-            "data_type": data_type
-        };
-        var closestDate = getClosestDate(datePadLocations, date);
-        if (timelineData[closestDate]) {
-            var dataTypeDict = timelineData[closestDate];
-            if (dataTypeDict[data_type]) {
-                var listOfEvents = dataTypeDict[data_type];
-                listOfEvents.push(eventAsDict);
-                dataTypeDict[data_type] = listOfEvents;
+
+            var data_type = $(this).attr('id');
+
+            var eventAsDict = {
+                "id": id,
+                "name": name,
+                "description": description,
+                "date": date,
+                "data_type": data_type
+            };
+            var closestDate = getClosestDate(datePadLocations, date);
+            if (creator.timelineData[closestDate]) {
+                var dataTypeDict = creator.timelineData[closestDate];
+                if (dataTypeDict[data_type]) {
+                    var listOfEvents = dataTypeDict[data_type];
+                    listOfEvents.push(eventAsDict);
+                    dataTypeDict[data_type] = listOfEvents;
+                }
+                else {
+                    dataTypeDict[data_type] = [eventAsDict];
+                }
             }
             else {
-                dataTypeDict[data_type] = [eventAsDict];
+                var dateGroup = {};
+                dateGroup[data_type] = [eventAsDict];
+                creator.timelineData[closestDate] = dateGroup;
             }
         }
-        else {
-            var dateGroup = {};
-            dateGroup[data_type] = [eventAsDict];
-            timelineData[closestDate] = dateGroup;
-        }
     });
-    return timelineData;
 }
 
 

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -207,7 +207,12 @@ function visibleTypes() {
 
 }
 
-
+/**
+ * gets the start and stop dates for the horizontal timeline
+ *
+ * @param zoom - the view state of the horizontal timeline
+ * @constructor
+ */
 function GetDateRange(zoom) {
     this.minDate = getDate(Date.now());
     this.maxDate = getDate('0');
@@ -221,26 +226,34 @@ function GetDateRange(zoom) {
         var string_date = $(this).find("#date").text().trim();
         var date = getDate(string_date);
         var data_type = $(this).attr('id');
+        var type = data_type.toLowerCase();
         validTypes = updateTypes(data_type, validTypes);
         rangeFinder.absMinDate = getMinDate(date, rangeFinder.absMinDate);
         rangeFinder.absMaxDate = getMaxDate(date, rangeFinder.absMaxDate);
-        if (rangeFinder.zoom) {
-            var type = data_type.toLowerCase();
-            if (type == 'vcc') {
-                rangeFinder.numVcc += 1;
+        if (type == 'vcc') {
+            rangeFinder.numVcc += 1;
+            if (rangeFinder.zoom) {
                 rangeFinder.minDate = getMinDate(date, rangeFinder.minDate);
-            } else if (type == 'fix') {
-                rangeFinder.numFix += 1;
+            }
+
+        }
+        if (type == 'fix') {
+            rangeFinder.numFix += 1;
+            if (rangeFinder.zoom) {
                 rangeFinder.maxDate = getMaxDate(date, rangeFinder.maxDate);
             }
         }
     });
+    if (rangeFinder.numVcc == 0 && rangeFinder.numFix == 0) {
+        $('#zoom-div').hide();
+    }
     if ((rangeFinder.zoom && (rangeFinder.numVcc == 0)) || !rangeFinder.zoom ) {
         rangeFinder.minDate = rangeFinder.absMinDate;
     }
     if ((rangeFinder.zoom && (rangeFinder.numFix == 0)) || !rangeFinder.zoom) {
         rangeFinder.maxDate = rangeFinder.absMaxDate;
     }
+
 }
 
 /**
@@ -293,8 +306,6 @@ var validTypes = [];
  * when the timeline is drawn
  * @type {Date}
  */
-
-
 
 var margin = {top: 10, right: 20, bottom: 30, left: 60},
     width = 960 - margin.left - margin.right,

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -235,10 +235,6 @@ function getMaxDate(date, maxDate) {
     }
 }
 
-/**
- * Global Variable to contain data types, used for filtering
- * @type {Array}
- */
 var validTypes = [];
 /**
  * Global variables used to store the minimum and maximum date, computed by initialize timeline and used
@@ -287,8 +283,6 @@ function initializeTimeline(zoom) {
             maxDate = getMaxDate(date, maxDate);
         }
     });
-    console.log(minDate);
-    console.log(maxDate);
     datePadLocations = getDatePadLocations(minDate, maxDate, slots);
     generateTypeSwitches(validTypes);
     generateTimeline(minDate, maxDate);
@@ -645,7 +639,7 @@ function createGroups(eventsInGroup) {
 }
 
 $(document).ready(function () {
-    initializeTimeline(false);
+    initializeTimeline(true);
 
     var $wrapper = $('#cd-timeline');
     $wrapper.find('.cd-timeline-block').sort(function (a, b) {
@@ -655,13 +649,15 @@ $(document).ready(function () {
     })
         .appendTo( $wrapper );
 
-    $('#zoom').click(function() {
-        var zoom = $('#zoomBool').val();
-        if ($('#zoomBool').val() == "true") {
-            $('#zoomBool').val("false");
+    $('#zoom-button').click(function() {
+        var zoom = $('#zoom-bool').val();
+        if ($('#zoom-bool').val() == "true") {
+            $('#zoom-bool').val("false");
+            $('#zoom-button').text('zoom in');
             zoom = false;
         } else {
-            $('#zoomBool').val("true");
+            $('#zoom-bool').val("true");
+            $('#zoom-button').text('zoom out');
             zoom = true;
         }
         $('#toggle-block').empty();

--- a/app/assets/stylesheets/vulnerabilities.scss
+++ b/app/assets/stylesheets/vulnerabilities.scss
@@ -699,3 +699,7 @@ Main components
     transform: translateX(0);
   }
 }
+
+.horizontal-center {
+  text-align: center;
+}

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -19,7 +19,7 @@
   <div class="small-11 small-centered columns">
     <h4 class="centered-title">Select Data Types</h4>
     <div class="data-toggles cd-container" id="toggle-block" onchange="generateTimeline()"></div>
-    <div id="zoom" class="button">Zoom</div>
+    <div id="zoom" class="button">Change View</div>
     <input type="hidden" id="zoomBool" name="zoomBool" value=false>
   </div>
 </div>

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -18,7 +18,7 @@
 <div class="row">
   <div class="small-11 small-centered columns">
     <h4 class="centered-title">Select Data Types</h4>
-    <div class="data-toggles cd-container horizontal-center" id="toggle-block" onchange="generateTimeline()"></div>
+    <div class="data-toggles cd-container horizontal-center" id="toggle-block"></div>
     <div class="horizontal-center" id="zoom-div">
       <div id="zoom-button" class="button">zoom out</div>
     </div>

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -19,6 +19,8 @@
   <div class="small-11 small-centered columns">
     <h4 class="centered-title">Select Data Types</h4>
     <div class="data-toggles cd-container" id="toggle-block" onchange="generateTimeline()"></div>
+    <div id="zoom" class="button">Zoom</div>
+    <input type="hidden" id="zoomBool" name="zoomBool" value=false>
   </div>
 </div>
 

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -18,9 +18,11 @@
 <div class="row">
   <div class="small-11 small-centered columns">
     <h4 class="centered-title">Select Data Types</h4>
-    <div class="data-toggles cd-container" id="toggle-block" onchange="generateTimeline()"></div>
-    <div id="zoom" class="button">Change View</div>
-    <input type="hidden" id="zoomBool" name="zoomBool" value=false>
+    <div class="data-toggles cd-container horizontal-center" id="toggle-block" onchange="generateTimeline()"></div>
+    <div class="horizontal-center" id="zoom-div">
+      <div id="zoom-button" class="button">zoom out</div>
+    </div>
+    <input type="hidden" id="zoom-bool" name="zoom-bool" value=true>
   </div>
 </div>
 


### PR DESCRIPTION
Ended up having to modify how the timeline and filters are generated to allow for zooming.

At the moment, the data type filters for types that aren't within the zoomed in date range still show up as checkboxes. Need to decide how to handle this. If i don't show the filters for the types out of range, it may seem like the CVE doesn't have those data types, unless the user zooms out.