### PR TITLE
Pull new release data (#193)

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,14 +1,14 @@
 class Release < ApplicationRecord
   has_many :events, as: :detail
-  
+
   # Required for Event model
   def title
-    "Release #{number}"
+    "Release #{name}"
   end
 
   # Required for Event model
   def description
-    "Release #{number} of #{project}"
+    "Release #{name}"
   end
 
   # Required for Event model

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,9 +55,8 @@ ActiveRecord::Schema.define(version: 20160914190348) do
   end
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "number",        null: false
+    t.string   "name",        null: false
     t.datetime "date_released", null: false
-    t.string   "project",       null: false
     t.jsonb    "notes",         null: false
   end
 

--- a/lib/event_generators/release_events.rb
+++ b/lib/event_generators/release_events.rb
@@ -4,9 +4,26 @@ class ReleaseEvents
       Event.create!(
         detail: release,
         style: style,
-        title_template: 'Release :title:',
+        title_template: ':title:',
         description_template: <<-EOS
-           Product release. :description:
+           Major release.
+
+           <p>
+             <b>Javascript Engine: :notes~js_eng:</b>
+           </p>
+
+           <p>
+             <b>Renderer: :notes~browser_eng:</b>
+           </p>
+
+           <p>
+             Significant changes:
+             <blockquote>
+             :notes~notes:
+             </blockquote>
+           </p>
+
+           Release information taken from <a href="https://en.wikipedia.org/wiki/Google_Chrome_version_history">Wikipedia</a>.
         EOS
       )
     end

--- a/lib/loaders/release_loader.rb
+++ b/lib/loaders/release_loader.rb
@@ -1,0 +1,14 @@
+class ReleaseLoader
+  def load_data(repo_path)
+    Dir["#{repo_path}/releases/*.yml"].each do |file|
+      yml = File.open(file) { |f| YAML.load(f) }
+      yml.each do | release_name, notes |
+        Release.create!(
+          name: release_name.to_s,
+          date_released: notes['date'].keys[0],
+          notes: notes,
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -24,7 +24,7 @@ namespace :data do
     gitName = 'chromium-vulnerabilities'
     findAddress = "./tmp/checkout/" + gitName
     gitAddress = 'https://github.com/andymeneely/chromium-vulnerabilities.git'
-    gitBranch = 'dev'
+    gitBranch = 'master'
     customEvent = "bounty"
     projectName = 'Chromium'
 

--- a/lib/tasks/chromium.rake
+++ b/lib/tasks/chromium.rake
@@ -6,6 +6,7 @@ require 'event_generators/fix_events'
 require 'event_generators/release_events'
 require 'event_generators/vcc_events'
 require 'event_generators/vulnerability_events'
+require 'loaders/release_loader'
 require_relative 'scheduler_task_handler'
 
 
@@ -23,7 +24,7 @@ namespace :data do
     gitName = 'chromium-vulnerabilities'
     findAddress = "./tmp/checkout/" + gitName
     gitAddress = 'https://github.com/andymeneely/chromium-vulnerabilities.git'
-    gitBranch = 'master'
+    gitBranch = 'dev'
     customEvent = "bounty"
     projectName = 'Chromium'
 
@@ -39,7 +40,11 @@ namespace :data do
       Scheduler_Task_Handler.gitParsing(git_logs)
       parsedYAMLFiles = Scheduler_Task_Handler.yamlParsing(ymlFiles)
       Scheduler_Task_Handler.cveMethods(parsedYAMLFiles, customEvent, projectName)
-      Scheduler_Task_Handler.gitMethods()
+      [
+        ReleaseLoader,
+      ].each do |loader|
+        loader.new.load_data(findAddress)
+      end
     end
 
     desc 'Generate event models'

--- a/lib/tasks/clear.rake
+++ b/lib/tasks/clear.rake
@@ -2,13 +2,15 @@ desc 'Clear the database. Be CAREFUL!!'
 namespace 'data' do
   task :clear => :environment do
     puts "Clearing data..."
-    Vulnerability.destroy_all
-    Commit.destroy_all
-    Fix.destroy_all
-    Vcc.destroy_all
-    Release.destroy_all
-    Filepath.destroy_all
-    Event.destroy_all
-    Style.destroy_all
+    ActiveRecord::Base.connection.execute "TRUNCATE commit_filepaths RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE commits RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE developers RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE events RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE filepaths RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE fixes RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE releases RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE styles RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE vccs RESTART IDENTITY"
+    ActiveRecord::Base.connection.execute "TRUNCATE vulnerabilities RESTART IDENTITY"
   end
 end

--- a/lib/tasks/scheduler_cve_methods.rb
+++ b/lib/tasks/scheduler_cve_methods.rb
@@ -3,18 +3,6 @@
 ########################################
 class Scheduler_CVE_Methods
 
-  def self.releaseData(parsed, projectName)
-      parsed["releases"].each do |key, date|
-        release = Release.new
-        release.number = key
-        release.date_released = date
-        release.project = projectName
-        #Something needs to go here
-        release.notes = "hello"
-        release.save
-      end
-  end
-
   def self.vulnerabilityData(vuln_data, event_added = "")
     vuln = Vulnerability.create!(
       cve: vuln_data["CVE"],

--- a/lib/tasks/scheduler_task_handler.rb
+++ b/lib/tasks/scheduler_task_handler.rb
@@ -72,10 +72,4 @@ class Scheduler_Task_Handler
         end
     end
 
-    def self.gitMethods()
-        # Generate events for commits on vulnerable files
-        puts "Generating commit events..."
-        CommitEvents.new.generate
-    end
-
 end

--- a/test/fixtures/releases.yml
+++ b/test/fixtures/releases.yml
@@ -5,15 +5,13 @@
 # below each fixture, per the syntax in the comments below
 #
 v17:
-  number: 17
+  name: '17'
   date_released: 2011-12-05
-  project: Chromium
   notes:
     Test: "Hello"
 
 v19:
-  number: 19
+  name: '19'
   date_released: 2012-12-05
-  project: Chromium
   notes:
     Test: "Hello"

--- a/test/lib/scheduler_test.rb
+++ b/test/lib/scheduler_test.rb
@@ -50,10 +50,4 @@ class SchedulerTest < ActiveSupport::TestCase
     added_event = Event.find_by detail_type: "Vulnerability"
     assert_equal "Vulnerability", added_event.detail_type
   end
-
-  test "releaseData adds Releases to db" do
-    Scheduler_CVE_Methods.releaseData(parsedReleases, "Chromium")
-    added_release = Release.find_by number: 18
-    assert_equal "Jan 30th, 2012".to_datetime.utc, added_release.date_released
-  end
 end

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -6,6 +6,6 @@ class ReleaseTest < ActiveSupport::TestCase
     assert Release.any?
   end
   test 'fixtures have infomation' do
-    assert_equal "Chromium", releases(:v17).project
+    assert_equal "17", releases(:v17).name.to_s
   end
 end


### PR DESCRIPTION
loaders: create them for release

This change creates a new design: loaders. Like event generators, these are similar-minded classes that are used to load in data. I did it for releases, but we can continue to refactor the other functionality out to it.

Also:
  * Updated the release event description to have new stuff
  * Updated tests
  * Better data:clear