### PR TITLE
markdown in vulnerability description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'd3-rails', '~> 4'
 gem 'modernizr-rails'
 # Fancy Javascript date handling
 gem 'momentjs-rails'
+# Markdown conversion
+gem 'kramdown'
 
 # Styling Framework
 gem 'foundation-rails', '~> 6.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kramdown (1.13.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -187,6 +188,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-datatables-rails (~> 3.4.0)
   jquery-rails
+  kramdown
   modernizr-rails
   momentjs-rails
   pg (>= 0.19.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def markdown(source)
+    Kramdown::Document.new(source).to_html.html_safe
+  end
 end

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -26,7 +26,7 @@
 </div>
 
 <div class="cd-container row callout">
-  <p><%= @vulnerability.description %></p>
+  <p><%= markdown(@vulnerability.description) %></p>
   <ul class="accordian vertical menu" data-accordion-menu>
      <li>
        <a href="#">Details</a>


### PR DESCRIPTION
We should support markdown for most of our free text, but here's a good place to start. 

Closes #111 