### PR TITLE
timeline.js(^erb): use jquery to get the color #130

### DIFF
--- a/app/assets/javascripts/timeline/timeline.js
+++ b/app/assets/javascripts/timeline/timeline.js
@@ -96,26 +96,7 @@ function getY(date, occupiedSlots) {
  * @returns {*} the color for that vulnerability
  */
 function getColor(type) {
-    <% Style.all.each do |es| %>
-
-    if (type == "<%= es.name %>") {
-        return "<%= es.color %>";
-    }
-    <% end %>
-    return "#888888";
-}
-
-/**
- * Gets correct img name given a vulnerability type
- * @param type - a string that specifies the type of vulnerability
- */
-function getImageName(type) {
-    <% Style.all.each do |es| %>
-    if (type == "<%= es.name %>") {
-        return "<%= es.icon %>";
-    }
-    <% end %>
-    return 'bug_report';
+    return $('#' + type + ' div.cd-timeline-img')[0].style.backgroundColor;
 }
 
 
@@ -388,9 +369,6 @@ function setupVerticalTimeline() {
             $(this).fadeOut();
         }
         else {
-            $(this).find("#timeline-icon").text(function () {
-                imageName = getImageName(dataType);
-            });
             $(this).fadeIn();
         }
     });

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -70,10 +70,15 @@
 
 <section id="cd-timeline" class="cd-container">
   <% @events.each do |e| %>
-      <div class="cd-timeline-block" id="<%= e.type %>" data-id='<%= e.date %>'>
+      <div id="<%= e.type %>" data-id='<%= e.date %>'
+           class="cd-timeline-block">
         <a id="<%= e.id %>"></a>
-        <div class="cd-timeline-img" style="background: <%= e.style.color %>">
-          <p class="material-icons md-32 md-light" id="timeline-icon"><%= e.style.icon %></p>
+        <div class="cd-timeline-img"
+             style="background: <%= e.style.color %>">
+          <p id="timeline-icon"
+             class="material-icons md-32 md-light">
+             <%= e.style.icon %>
+          </p>
         </div> <!-- cd-timeline-img -->
         <div class="cd-timeline-content">
           <h2 id="title"><%= e.title %></h2>


### PR DESCRIPTION
This change removes the ERB calls in timeline.js.erb 

This is so that we don't rely upon a one-time call to the database to get our styles.

Closes #130