### PR TITLE
Timeline zooming: use vuln if there is no vcc #191 #204

### DIFF
--- a/app/assets/javascripts/timeline/timeline.js
+++ b/app/assets/javascripts/timeline/timeline.js
@@ -357,21 +357,6 @@ function removeFilteredTypes(timelineTypeKeys) {
     return timelineTypeKeys;
 }
 
-
-/**
- * Generate an HTML blob that will be used for creating mini-blocks inside of the main timeline groups
- * @param group a group, with size of groupSize, containing dictionary items corresponding to each element in that group
- */
-function createTooltipGroupHTML(group) {
-    var html = "";
-    group.forEach(function (event) {
-        if (event && typeof event === 'object') {
-            html += '<a onclick="return true" href="#' + event["id"] + '">' + toTitleCase(renameTypeLabel(event.name)) + '</a><br>'
-        }
-    });
-    return html;
-}
-
 /**
  * Function to setup the timeline to use correct styling and hide hidden blocks
  */

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -257,7 +257,7 @@ function GetDateRange(zoom) {
             }
         }
     });
-    if (rangeFinder.numVcc == 0 && rangeFinder.numFix == 0) {
+    if (rangeFinder.numVcc == 0 && rangeFinder.numFix == 0 && rangeFinder.numVuln == 0) {
         $('#zoom-div').hide();
     }
     if ((rangeFinder.zoom && (rangeFinder.numVcc == 0))) {

--- a/app/assets/javascripts/timeline/timeline.js.erb
+++ b/app/assets/javascripts/timeline/timeline.js.erb
@@ -224,7 +224,9 @@ function GetDateRange(zoom) {
     this.maxDate = getDate(0);
     this.absMinDate = getDate(Date.now());
     this.absMaxDate = getDate(0);
+    this.vulnMinDate = getDate(Date.now());
     this.numVcc = 0;
+    this.numVuln = 0;
     this.numFix = 0;
     this.zoom = zoom;
     var rangeFinder = this;
@@ -242,6 +244,12 @@ function GetDateRange(zoom) {
                 rangeFinder.minDate = getMinDate(date, rangeFinder.minDate);
             }
         }
+        if (type == 'vulnerability') {
+            rangeFinder.numVuln += 1;
+            if (rangeFinder.zoom) {
+                rangeFinder.vulnMinDate = getMinDate(date, rangeFinder.vulnMinDate)
+            }
+        }
         if (type == 'fix') {
             rangeFinder.numFix += 1;
             if (rangeFinder.zoom) {
@@ -252,7 +260,14 @@ function GetDateRange(zoom) {
     if (rangeFinder.numVcc == 0 && rangeFinder.numFix == 0) {
         $('#zoom-div').hide();
     }
-    if ((rangeFinder.zoom && (rangeFinder.numVcc == 0)) || !rangeFinder.zoom ) {
+    if ((rangeFinder.zoom && (rangeFinder.numVcc == 0))) {
+        if (rangeFinder.numVuln > 0) {
+            rangeFinder.minDate = rangeFinder.vulnMinDate;
+        } else {
+            rangeFinder.minDate = rangeFinder.absMinDate;
+        }
+    }
+    if (!rangeFinder.zoom) {
         rangeFinder.minDate = rangeFinder.absMinDate;
     }
     if ((rangeFinder.zoom && (rangeFinder.numFix == 0)) || !rangeFinder.zoom) {

--- a/lib/tasks/synthetic.rake
+++ b/lib/tasks/synthetic.rake
@@ -50,7 +50,7 @@ namespace 'data' do
 
     Event.create!(
       detail: v,
-      type_template: 'bounty',
+      type_template: 'vulnerability',
       style: vuln_style
     )
 


### PR DESCRIPTION
closes #191 

1984: there is no VCC but there is a Vulnerability so the start date is zoomed on the Vulnerability.
<img width="993" alt="screen shot 2017-03-03 at 11 11 55 am" src="https://cloud.githubusercontent.com/assets/3083841/23558618/4e7a083a-0002-11e7-8b0f-7b40c1ead347.png">
