### PR TITLE
Issue 234 - horizontal timeline handle column overflows for events

### DIFF
--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -62,6 +62,7 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     this.setup = function() {
         this.initEDict();
         this.generateData();
+        console.log(this.eDict);
         if(this.filtersGenerated === true) {
             this.filterEvents();
         }
@@ -149,9 +150,10 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
         document.getElementById('cd-timeline').appendChild(toAdd);
     };
 
+    /**
+     * draw filters below horizontal timeline
+     */
     this.generateFilters = function() {
-        //draw filters (see generateTypeSwitches()
-        //callback for filters to update horizontal timeline on change
         var container = document.createDocumentFragment();
         for (var i = 0; i < this.validTypes.length; i++) {
             // generate checkbox
@@ -286,6 +288,7 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     };
 
     this.filterEvents = function() {
+        this.hiddenTypes = [];
         for (var i = 0; i < this.validTypes.length; i++) {
             if ($('#toggle-block').children.length > 0) {
                 if (!($('#' + this.validTypes[i] + '-toggle').is(':checked'))) {
@@ -293,16 +296,19 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         }
+        console.log(this.eDict);
         var cols = Object.keys(this.eDict);
         var self = this;
         cols.forEach(function(key) {
             var eArr = self.eDict[key];
             for (var i = 0; i < eArr.length; i++) {
                 if (self.hiddenTypes.indexOf(eArr[i].type) != -1) {
-                    self.eDict[key].splice(i);
+                    self.eDict[key].splice(i, 1);
+                    i -= 1;
                 }
             }
         });
+        console.log(this.eDict);
     };
 
     /**

--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -316,24 +316,37 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
         var cols = Object.keys(this.eDict);
         var tipId = 0;
         var tip;
+        var oIndex = 0;
+        var oCount = 0;
         var self = this;
         cols.forEach(function(key) {
             var eArr = self.eDict[key];
-            var overFArr = [];
+            var colOverFArr = [];
             for (var i = 0; i < eArr.length; i++) {
                 var event = eArr[i];
                 tip = self.renderToolTips(tip, tipId);
                 tipId += 1;
-                if (i < self.cLim) {
+                if (self.cLim === self.cLowerLim) {
+                    var limit = self.cLim;
+                } else {
+                    var limit = self.cLim - 4;
+                }
+                if (i < limit) {
                     if (event.type == 'release') {
                         self.drawFlag(tip, new Date(key), i, event);
                     } else {
                         self.drawChic(tip, new Date(key), i, event);
                     }
                 } else {
-                    overFArr.push(event);
+                    if (oCount === 0) {
+                        oIndex = i;
+                    }
+                    oCount += 1;
+                    colOverFArr.push(event);
                 }
-                self.drawOverflow();
+            }
+            if (colOverFArr.length > 0) {
+                self.drawOverflow(tip, new Date(key), oIndex, colOverFArr);
             }
         });
     };
@@ -355,6 +368,20 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
             });
 
         return tip;
+    };
+
+    this.showOverflowHover = function(events) {
+        $('#legend-body').html(
+            '<h5>More Events: </h5>'
+        );
+        events.forEach(function(event, index) {
+            $('#legend-body').append(
+                '<li>' +
+                    event.type + ': ' +
+                moment(event.date).format('MMMM Do YYYY, h:mm a') +
+                '</li>'
+            );
+        });
     };
 
     this.showTooltip = function(tip, event) {
@@ -451,8 +478,31 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
             });
     };
 
-    this.drawOverflow = function() {
-        return;
+    this.drawOverflow = function(tip, col, yIndex, events) {
+        var startX = this.x(col) + (this.chicWidth / 2);
+        var startY = this.y(yIndex + 1);
+        var self = this;
+        this.svg.append("path")
+            .attr("d", "M" + startX + " " + startY + " V " + this.chicHeight + "M" + (startX - (this.chicHeight / 2)) + " " + (startY + (this.chicHeight / 2)) + " H " + (startX + (this.chicHeight/2)) )
+            .attr("stroke-width", 3)
+            .attr("stroke", "#808080")
+            .on('click', function () { // link to horizontal-timeline
+                window.location.href = '#' + events[0].id;
+                d3.select(this).attr("stroke", "#00FF00")
+            })
+            .on("mouseenter", function () { // show chicklet
+                d3.select(this).attr("stroke", "#9933ff")
+                    .attr("fill", function () {
+                        return "#9933ff"
+                    });
+                //self.showTooltip(tip, events[0]);
+                self.showOverflowHover(events);
+            })
+            .on("mouseleave", function () { // hide tooltip
+                d3.select(this).attr("stroke", "#808080")
+                tip.transition()
+                    .style("display", "none");
+            });
     };
 
     /**

--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -62,7 +62,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     this.setup = function() {
         this.initEDict();
         this.generateData();
-        console.log(this.eDict);
         if(this.filtersGenerated === true) {
             this.filterEvents();
         }
@@ -296,7 +295,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         }
-        console.log(this.eDict);
         var cols = Object.keys(this.eDict);
         var self = this;
         cols.forEach(function(key) {
@@ -308,7 +306,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         });
-        console.log(this.eDict);
     };
 
     /**


### PR DESCRIPTION
For now I've just listed the overflow event types and their dates in the tooltip space. Any suggestions on what to put here?

Clicking on the overflow "plus" will bring the user to the earliest event in the overflow on the vertical timeline.

<img width="1440" alt="screen shot 2017-04-06 at 2 48 24 pm" src="https://cloud.githubusercontent.com/assets/3083841/24770514/2c1ad3e6-1ad8-11e7-9de2-fadf8a960882.png">

Resolves #234 
