### PR TITLE
Issue 240 - Toggled filters carry over between zoom states

### DIFF
--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -22,10 +22,11 @@
  * @param svgWidth (int) - width of svg
  * @param svgMargin (object) - margins for svg
  * @param filtersGenerated (bool) - whether or not filters have been generated yet
+ * @param hiddenTypes (array) - data-toggles that have been unchecked
  * @constructor
  */
 function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChicHeight, chicWidth, zoom, minDate,
-                            maxDate, eVcc, eVuln, lFix, svgHeight, svgWidth, svgMargin, filtersGenerated) {
+                            maxDate, eVcc, eVuln, lFix, svgHeight, svgWidth, svgMargin, filtersGenerated, hiddenTypes) {
     //instance variables
     this.events = events;
     this.cLowerLim = cLowerLim;
@@ -54,7 +55,7 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     this.x;
     this.y;
     this.filtersGenerated = filtersGenerated;
-    this.hiddenTypes = [];
+    this.hiddenTypes = hiddenTypes;
 
     /**
      * setup sequence. call this.generate after.
@@ -111,7 +112,9 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                     self.validTypes.push(e.type);
                 }
                 var col = self.getCol(e.date);
-                self.eDict[col].push(e);
+                if (self.hiddenTypes.indexOf(e.type) === -1) {
+                    self.eDict[col].push(e);
+                }
             }
         });
     };
@@ -162,7 +165,11 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
             var checkbox = document.createElement('input');
             checkbox.id = this.validTypes[i] + "-toggle";
             checkbox.type = "checkbox";
-            checkbox.checked = true;
+            if (this.hiddenTypes.indexOf(this.validTypes[i]) === -1) {
+                checkbox.checked = true;
+            } else {
+                checkbox.checked = false;
+            }
             // generate label for checkbox
             var label = document.createElement('label');
             label.htmlFor = this.validTypes[i] + "-toggle";
@@ -287,7 +294,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     };
 
     this.filterEvents = function() {
-        this.hiddenTypes = [];
         for (var i = 0; i < this.validTypes.length; i++) {
             if ($('#toggle-block').children.length > 0) {
                 if (!($('#' + this.validTypes[i] + '-toggle').is(':checked'))) {
@@ -499,5 +505,4 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
             return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
         });
     }
-
 }

--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -62,6 +62,7 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     this.setup = function() {
         this.initEDict();
         this.generateData();
+        console.log(this.eDict);
         if(this.filtersGenerated === true) {
             this.filterEvents();
         }
@@ -149,9 +150,10 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
         document.getElementById('cd-timeline').appendChild(toAdd);
     };
 
+    /**
+     * draw filters below horizontal timeline
+     */
     this.generateFilters = function() {
-        //draw filters (see generateTypeSwitches()
-        //callback for filters to update horizontal timeline on change
         var container = document.createDocumentFragment();
         for (var i = 0; i < this.validTypes.length; i++) {
             // generate checkbox
@@ -286,6 +288,7 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     };
 
     this.filterEvents = function() {
+        this.hiddenTypes = [];
         for (var i = 0; i < this.validTypes.length; i++) {
             if ($('#toggle-block').children.length > 0) {
                 if (!($('#' + this.validTypes[i] + '-toggle').is(':checked'))) {
@@ -293,16 +296,19 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         }
+        console.log(this.eDict);
         var cols = Object.keys(this.eDict);
         var self = this;
         cols.forEach(function(key) {
             var eArr = self.eDict[key];
             for (var i = 0; i < eArr.length; i++) {
                 if (self.hiddenTypes.indexOf(eArr[i].type) != -1) {
-                    self.eDict[key].splice(i);
+                    self.eDict[key].splice(i, 1);
+                    i -= 1;
                 }
             }
         });
+        console.log(this.eDict);
     };
 
     /**

--- a/app/assets/javascripts/timeline/HorizontalTimeline.js
+++ b/app/assets/javascripts/timeline/HorizontalTimeline.js
@@ -62,7 +62,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
     this.setup = function() {
         this.initEDict();
         this.generateData();
-        console.log(this.eDict);
         if(this.filtersGenerated === true) {
             this.filterEvents();
         }
@@ -296,7 +295,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         }
-        console.log(this.eDict);
         var cols = Object.keys(this.eDict);
         var self = this;
         cols.forEach(function(key) {
@@ -308,7 +306,6 @@ function HorizontalTimeline(events, cLowerLim, cUpperLim, minChicHeight, maxChic
                 }
             }
         });
-        console.log(this.eDict);
     };
 
     /**

--- a/app/assets/javascripts/timeline/timeline.js
+++ b/app/assets/javascripts/timeline/timeline.js
@@ -27,7 +27,8 @@ function bindDataToggleCallback(h, sEvents, cLowerLim, cUpperLim, minChicHeight,
             height,
             width,
             margin,
-            true
+            true,
+            []
         );
         h.setup();
         h.generate();
@@ -50,6 +51,7 @@ function bindZoomEvents(h, sEvents, cLowerLim, cUpperLim, minChicHeight, maxChic
             $('#zoom-button').text('zoom_out');
             zoom = true;
         }
+        var hiddenTypes = getFilterState();
         $('#toggle-block').empty();
         h = {};
         h = new HorizontalTimeline(
@@ -68,7 +70,8 @@ function bindZoomEvents(h, sEvents, cLowerLim, cUpperLim, minChicHeight, maxChic
             height,
             width,
             margin,
-            false
+            false,
+            hiddenTypes
         );
         h.setup();
         h.generate();
@@ -120,6 +123,24 @@ function bindScrollEvents() {
         $('html, body').animate({scrollTop: 0}, 600);
         return false;
     });
+}
+
+/**
+ * return an array of all the unchecked filters
+ * @returns {Array}
+ */
+function getFilterState() {
+    var hiddenTypes = [];
+    $('#toggle-block').children('span').each(function() {
+        if (!($(this).children("input[type='checkbox']:first").is(":checked")
+            )) {
+            var type = $(this).children("input[type='checkbox']:first").attr('id');
+            type = type.split('-')[0];
+            hiddenTypes.push(type);
+        }
+    });
+
+    return hiddenTypes;
 }
 
 /**
@@ -268,6 +289,7 @@ $(document).ready(function () {
     var cUpperLim = 25;
     var zoom = true;
     var filtersGenerated = false;
+    var hiddenTypes = [];
 
     var h = new HorizontalTimeline(
         sEvents,
@@ -285,7 +307,8 @@ $(document).ready(function () {
         height,
         width,
         margin,
-        filtersGenerated
+        filtersGenerated,
+        hiddenTypes
     );
 
     h.setup();


### PR DESCRIPTION
Filter checked state now carries over between zoom states. In the case where a toggle doesn't exist in the current zoom view, but exists in the next zoom view, it defaults that toggle as checked. Do we want it to default as unchecked or checked?

For example for 1984-0519, bounty doesn't exist in the zoomed in state, so when you zoom out, it will default the bounty toggle to checked, which is the same as the default for all toggles when the timeline is first generated.

branched this off of #239 because master is currently broken on vulnerabilities/show page.