### PR TITLE
Autolink URL's in the views.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'coderay'
 
 gem 'listen', '~> 3.0' # NOTE: for TCP functionality, use '~> 2.10' for now
+
+# autolinks
+gem 'rinku'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
+    rinku (2.0.3)
     ruby_dep (1.5.0)
     sass (3.4.25)
     sass-rails (5.0.6)
@@ -209,6 +210,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.1.4, >= 5.0.0.1)
   rb-readline
+  rinku
   sass-rails (~> 5.0)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/global/externalLinkWarning.js
+++ b/app/assets/javascripts/global/externalLinkWarning.js
@@ -1,0 +1,32 @@
+$(document).ready(function(){
+    var root = new RegExp(location.host);
+
+    $('a').each(function(){
+
+        if(root.test($(this).attr('href'))){
+            $(this).addClass('local');
+        }
+        else{
+            // a link that does not contain the current host
+            var url = $(this).attr('href');
+            if(url) {
+                if(url.length > 1)
+                {
+                    $(this).addClass('external');
+                }
+            }
+        }
+    });
+
+    $('a.external').on('click', function(e){
+
+        e.preventDefault();
+        var answer = confirm("You are about to leave the Vulnerability History Project website and view the content of an external website. Do you want to proceed?");
+
+        if (answer){
+            window.location = $(this).attr('href');
+        }
+
+    });
+
+});

--- a/app/assets/javascripts/global/externalLinkWarning.js
+++ b/app/assets/javascripts/global/externalLinkWarning.js
@@ -2,8 +2,7 @@ $(document).ready(function(){
     var root = new RegExp(location.host);
 
     $('a').each(function(){
-
-        if(root.test($(this).attr('href'))){
+        if($(this).attr('href') != null && (root.test($(this).attr('href')) || $(this).attr('href').indexOf('/') == 0)) {
             $(this).addClass('local');
         }
         else{

--- a/app/views/vulnerabilities/show.html.erb
+++ b/app/views/vulnerabilities/show.html.erb
@@ -35,7 +35,7 @@
 </div>
 
 <div class="cd-container row callout">
-  <p><%= markdown(@vulnerability.description) %></p>
+  <p><%= markdown(Rinku.auto_link(@vulnerability.description)) %></p>
   <ul class="accordian vertical menu" data-accordion-menu>
      <li>
        <a href="#">Details</a>


### PR DESCRIPTION
implemented on the vulnerability description only right now.

/vulnerabilities/137
cve-2010-3248 has a link in the vulnerability description.

@andymeneely Autolinking conflicts with Markdown links. Do we want to autolink everything or only certain fields?